### PR TITLE
Exit if last commit message contains `[ci skip]`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,10 @@ name: 'octorelease'
 description: 'Extensible GitHub action to publish semantic releases'
 author: 't1m0thyj'
 inputs:
+  ci-skip:
+    description: 'Specify whether to detect [ci skip] in last commit message'
+    required: false
+    default: 'true'
   config-dir:
     description: 'Custom directory to search for release configuration'
     required: false

--- a/dist/github.js
+++ b/dist/github.js
@@ -1675,6 +1675,16 @@ var require_inputs = __commonJS({
     var path2 = __importStar(require("path"));
     var core = __importStar(require_core());
     var Inputs2 = class {
+      static get ciSkip() {
+        try {
+          return core.getBooleanInput("ci-skip");
+        } catch (error) {
+          if (error instanceof TypeError) {
+            return true;
+          }
+          throw error;
+        }
+      }
       static get configDir() {
         const input = core.getInput("config-dir");
         return input ? path2.resolve(this.rootDir, input) : void 0;
@@ -18521,7 +18531,7 @@ var require_utils5 = __commonJS({
       });
     };
     Object.defineProperty(exports, "__esModule", { value: true });
-    exports.verifyConditions = exports.loadPlugins = exports.dryRunTask = exports.buildContext = void 0;
+    exports.getLastCommitMessage = exports.verifyConditions = exports.loadPlugins = exports.dryRunTask = exports.buildContext = void 0;
     var fs2 = __importStar(require("fs"));
     var path2 = __importStar(require("path"));
     var exec = __importStar(require_exec());
@@ -18621,6 +18631,13 @@ var require_utils5 = __commonJS({
         return { old: oldVersion, new: oldVersion, prerelease };
       });
     }
+    function getLastCommitMessage() {
+      return __awaiter(this, void 0, void 0, function* () {
+        const cmdOutput = yield exec.getExecOutput("git", ["log", "-1", "--pretty=format:%s"], { ignoreReturnCode: true });
+        return cmdOutput.exitCode === 0 && cmdOutput.stdout.trim() || void 0;
+      });
+    }
+    exports.getLastCommitMessage = getLastCommitMessage;
     function loadCiEnv() {
       return __awaiter(this, void 0, void 0, function* () {
         const envCi = require_env_ci()();

--- a/dist/npm.js
+++ b/dist/npm.js
@@ -2498,6 +2498,16 @@ var require_inputs = __commonJS({
     var path5 = __importStar(require("path"));
     var core = __importStar(require_core());
     var Inputs = class {
+      static get ciSkip() {
+        try {
+          return core.getBooleanInput("ci-skip");
+        } catch (error) {
+          if (error instanceof TypeError) {
+            return true;
+          }
+          throw error;
+        }
+      }
       static get configDir() {
         const input = core.getInput("config-dir");
         return input ? path5.resolve(this.rootDir, input) : void 0;
@@ -18294,7 +18304,7 @@ var require_utils5 = __commonJS({
       });
     };
     Object.defineProperty(exports, "__esModule", { value: true });
-    exports.verifyConditions = exports.loadPlugins = exports.dryRunTask = exports.buildContext = void 0;
+    exports.getLastCommitMessage = exports.verifyConditions = exports.loadPlugins = exports.dryRunTask = exports.buildContext = void 0;
     var fs5 = __importStar(require("fs"));
     var path5 = __importStar(require("path"));
     var exec3 = __importStar(require_exec());
@@ -18394,6 +18404,13 @@ var require_utils5 = __commonJS({
         return { old: oldVersion, new: oldVersion, prerelease };
       });
     }
+    function getLastCommitMessage() {
+      return __awaiter(this, void 0, void 0, function* () {
+        const cmdOutput = yield exec3.getExecOutput("git", ["log", "-1", "--pretty=format:%s"], { ignoreReturnCode: true });
+        return cmdOutput.exitCode === 0 && cmdOutput.stdout.trim() || void 0;
+      });
+    }
+    exports.getLastCommitMessage = getLastCommitMessage;
     function loadCiEnv() {
       return __awaiter(this, void 0, void 0, function* () {
         const envCi = require_env_ci()();

--- a/packages/core/src/inputs.ts
+++ b/packages/core/src/inputs.ts
@@ -27,6 +27,20 @@ export class Inputs {
     private static readonly rootDir = process.cwd();
 
     /**
+     * Specify whether to detect [ci skip] in last commit message
+     */
+    public static get ciSkip(): boolean {
+        try {
+            return core.getBooleanInput("ci-skip");
+        } catch (error) {
+            if (error instanceof TypeError) {
+                return true;
+            }
+            throw error;
+        }
+    }
+
+    /**
      * Custom directory to search for release configuration.
      */
     public static get configDir(): string | undefined {

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -32,6 +32,9 @@ async function run(): Promise<void> {
         if (context == null) {
             core.info("Current branch is not a release branch, exiting now");
             process.exit();
+        } else if (Inputs.ciSkip && (await utils.getLastCommitMessage())?.includes("[ci skip]")) {
+            core.info("Commit message contains CI skip phrase, exiting now");
+            process.exit();
         }
 
         const pluginsLoaded = await utils.loadPlugins(context);

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -149,6 +149,15 @@ async function buildVersionInfo(branch: IProtectedBranch, tagPrefix: string): Pr
 }
 
 /**
+ * Retrieve most recent Git commit message if there is one.
+ * @returns Commit message or undefined if there is no Git history
+ */
+export async function getLastCommitMessage(): Promise<string | undefined> {
+    const cmdOutput = await exec.getExecOutput("git", ["log", "-1", "--pretty=format:%s"], { ignoreReturnCode: true });
+    return cmdOutput.exitCode === 0 && cmdOutput.stdout.trim() || undefined;
+}
+
+/**
  * Load CI properties like branch name, commit SHA, and repository slug.
  * @returns CI environment for the `context.ci` property
  */


### PR DESCRIPTION
This PR restores code from https://github.com/octorelease/octorelease/commit/d41ab90103211ef502c77ed70501089e3dbd8bbf to check for CI skip, and makes it optional.

After going back and forth several times in the past on deciding whether or not Octorelease should check for `[ci skip]`, decided that it should by default, after an incident where a Jenkins pipeline kept running itself on a prerelease branch and publishing thousands of new versions. 😛 