### PR TITLE
Fix duplicate version headers in changelog

### DIFF
--- a/dist/changelog.js
+++ b/dist/changelog.js
@@ -3085,7 +3085,7 @@ function getPackageChangelog(context, changelogFile, headerLine) {
   return releaseNotes.trim() || void 0;
 }
 function updatePackageChangelog(context, changelogFile, headerLine) {
-  if (fs.existsSync(changelogFile)) {
+  if (context.version.new !== context.version.old && fs.existsSync(changelogFile)) {
     const oldContents = fs.readFileSync(changelogFile, "utf-8");
     const newContents = oldContents.replace(headerLine, `## \`${context.version.new}\``);
     if (newContents !== oldContents) {

--- a/packages/changelog/src/version.ts
+++ b/packages/changelog/src/version.ts
@@ -73,7 +73,7 @@ function getPackageChangelog(context: IContext, changelogFile: string, headerLin
 }
 
 function updatePackageChangelog(context: IContext, changelogFile: string, headerLine: string): boolean {
-    if (fs.existsSync(changelogFile)) {
+    if (context.version.new !== context.version.old && fs.existsSync(changelogFile)) {
         const oldContents = fs.readFileSync(changelogFile, "utf-8");
         const newContents = oldContents.replace(headerLine, `## \`${context.version.new}\``);
 


### PR DESCRIPTION
Fixes #39 and should prevent commits like this one from happening: https://github.com/zowe/imperative/commit/3774d80fee7db61226403e2833361c5518f3ac31